### PR TITLE
Avoid to append if read result is not String

### DIFF
--- a/lib/ruby-fifo/fifo.rb
+++ b/lib/ruby-fifo/fifo.rb
@@ -105,8 +105,8 @@ class Fifo
   # and gets.
   def readline
     str = ""
-    while ($_ = self.read(1)) != "\n"
-      str << $_
+    while (c = self.read(1)) != "\n"
+      str << c if c.is_a?(String)
     end
     str << "\n"
   end


### PR DESCRIPTION
# Background

In some case when writer program closes named pipe, [read(1) method](https://github.com/shurizzle/ruby-fifo/blob/fd20588f10296c5d44779660232e529db187439e/lib/ruby-fifo/fifo.rb#L108) returns not String type. Then `str` can not append non String type variable and throw exception.

# What is changed

Avoid appending procedure to `str` if a result of `read()` is not String